### PR TITLE
feat(v0.7.1): add MIT license and update API for v0.7.1 support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 WaterCrawl-PHP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WaterCrawl PHP SDK
+# WaterCrawl PHP Client
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/watercrawl/php.svg?style=flat-square)](https://packagist.org/packages/watercrawl/php)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/watercrawl/watercrawl-php/release.yml?branch=main&style=flat-square)](https://github.com/watercrawl/watercrawl-php/actions?query=workflow%3ARelease)
@@ -6,7 +6,7 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/watercrawl/php.svg?style=flat-square)](https://packagist.org/packages/watercrawl/php)
 [![License](https://img.shields.io/packagist/l/watercrawl/php.svg?style=flat-square)](https://packagist.org/packages/watercrawl/php)
 
-PHP SDK for WaterCrawl REST APIs. This package provides a simple and elegant way to interact with WaterCrawl's web scraping and crawling services.
+PHP Client for WaterCrawl REST APIs. This package provides a simple and elegant way to interact with WaterCrawl's web scraping and crawling services.
 
 ## Installation
 
@@ -49,12 +49,233 @@ foreach ($client->monitorCrawlRequest($result['uuid']) as $update) {
 }
 ```
 
+## API Examples
+
+### Crawling Operations
+
+#### List all crawl requests
+
+```php
+// Get the first page of requests (default page size: 10)
+$requests = $client->getCrawlRequestsList();
+
+// Specify page number and size
+$requests = $client->getCrawlRequestsList(2, 20);
+```
+
+#### Get a specific crawl request
+
+```php
+$request = $client->getCrawlRequest('request-uuid');
+```
+
+#### Create a crawl request
+
+```php
+// Simple request with just a URL
+$request = $client->createCrawlRequest('https://example.com');
+
+// Advanced request with options
+$request = $client->createCrawlRequest(
+    'https://example.com',
+    [
+        'max_depth' => 1, // maximum depth to crawl
+        'page_limit' => 1, // maximum number of pages to crawl
+        'allowed_domains' => [], // allowed domains to crawl
+        'exclude_paths' => [], // exclude paths
+        'include_paths' => [] // include paths
+    ],
+    [
+        'exclude_tags' => [], // exclude tags from the page
+        'include_tags' => [], // include tags from the page
+        'wait_time' => 1000, // wait time in milliseconds after page load
+        'include_html' => false, // the result will include HTML
+        'only_main_content' => true, // only main content of the page
+        'include_links' => false, // if true the result will include links
+        'timeout' => 15000, // timeout in milliseconds
+        'accept_cookies_selector' => null, // accept cookies selector
+        'locale' => "en-US", // locale
+        'extra_headers' => [], // extra headers
+        'actions' => [] // actions to perform
+    ],
+    [] // plugin options
+);
+```
+
+#### Stop a crawl request
+
+```php
+$client->stopCrawlRequest('request-uuid');
+```
+
+#### Download a crawl request result
+
+```php
+// Download the crawl request results
+$results = $client->downloadCrawlRequest('request-uuid');
+```
+
+#### Monitor a crawl request
+
+```php
+// Monitor with automatic result download (default)
+foreach ($client->monitorCrawlRequest('request-uuid') as $event) {
+    if ($event['type'] === 'state') {
+        echo "Crawl state: {$event['data']['status']}\n";
+    } elseif ($event['type'] === 'result') {
+        echo "Received result for: {$event['data']['url']}\n";
+    }
+}
+
+// Monitor without downloading results
+foreach ($client->monitorCrawlRequest('request-uuid', false) as $event) {
+    echo "Event type: {$event['type']}\n";
+}
+```
+
+#### Get crawl request results
+
+```php
+// Get the first page of results
+$results = $client->getCrawlRequestResults('request-uuid');
+
+// Specify page number and size
+$results = $client->getCrawlRequestResults('request-uuid', 2, 20);
+```
+
+#### Quick URL scraping
+
+```php
+// Synchronous scraping (default)
+$result = $client->scrapeUrl('https://example.com');
+
+// With page options
+$result = $client->scrapeUrl(
+    'https://example.com',
+    [
+        'wait_time' => 1000,
+        'only_main_content' => true
+    ]
+);
+
+// Asynchronous scraping
+$request = $client->scrapeUrl('https://example.com', [], [], false);
+// Later check for results with getCrawlRequest
+```
+
+### Sitemap Operations
+
+#### Download a sitemap
+
+```php
+// Download using a crawl request object
+$crawlRequest = $client->getCrawlRequest('request-uuid');
+$sitemap = $client->downloadSitemap($crawlRequest);
+
+// Or download using just the UUID
+$sitemap = $client->downloadSitemap('request-uuid');
+
+// Process sitemap entries
+foreach ($sitemap as $entry) {
+    echo "URL: {$entry['url']}, Title: {$entry['title']}\n";
+}
+```
+
+#### Download sitemap as graph data
+
+```php
+// You need to provide crawl request uuid or crawl request object
+$graphData = $client->downloadSitemapGraph('request-uuid');
+```
+
+#### Download sitemap as markdown
+
+```php
+// You need to provide crawl request uuid or crawl request object
+$markdown = $client->downloadSitemapMarkdown('request-uuid');
+
+// Save to a file
+file_put_contents('sitemap.md', $markdown);
+```
+
+### Search Operations
+
+#### Get search requests list
+
+```php
+// Get the first page of search requests
+$searchRequests = $client->getSearchRequestsList();
+
+// Specify page number and size
+$searchRequests = $client->getSearchRequestsList(2, 20);
+```
+
+#### Create a search request
+
+```php
+// Simple search with synchronous results
+$results = $client->createSearchRequest('php programming');
+
+// Search with options and limited results
+$results = $client->createSearchRequest(
+    'php tutorial',
+    [
+        'language' => null, // language code e.g. "en" or "fr"
+        'country' => null, // country code e.g. "us" or "fr"
+        'time_range' => 'any', // time range e.g. "any", "hour", "day", "week", "month", "year"
+        'search_type' => 'web', // search type e.g. "web"
+        'depth' => 'basic' // depth e.g. "basic", "advanced", "ultimate"
+    ],
+    5, // limit the number of results
+    true, // wait for results
+    true // download results
+);
+
+// Asynchronous search
+$searchRequest = $client->createSearchRequest(
+    'machine learning',
+    [], // search options
+    5, // limit the number of results
+    false, // Don't wait for results
+    false // Don't download results
+);
+```
+
+#### Monitor a search request
+
+```php
+// Monitor a search request
+foreach ($client->monitorSearchRequest('search-uuid') as $event) {
+    if ($event['type'] === 'state') {
+        echo "Search state: {$event['status']}\n";
+    }
+}
+
+// Monitor without downloading results
+foreach ($client->monitorSearchRequest('search-uuid', false) as $event) {
+    echo "Event: " . json_encode($event) . "\n";
+}
+```
+
+#### Get a search request
+
+```php
+$searchRequest = $client->getSearchRequest('search-uuid');
+```
+
+#### Stop a search request
+
+```php
+$client->stopSearchRequest('search-uuid');
+```
+
 ## Features
 
 - Simple and intuitive API
 - Real-time crawl monitoring
 - Configurable scraping options
 - Automatic response handling
+- Support for sitemaps and search operations
 - PHP 7.4+ compatibility
 - Proper UTF-8 support
 
@@ -64,13 +285,17 @@ foreach ($client->monitorCrawlRequest($result['uuid']) as $update) {
 composer test
 ```
 
+## Compatibility
+
+- WaterCrawl API >= 0.7.1
+
 ## Changelog
 
-Please see [CHANGELOG.md](CHANGELOG.md) for more information on what has changed recently.
+Please see [CHANGELOG.md](https://github.com/watercrawl/watercrawl-php/blob/main/CHANGELOG.md) for more information on what has changed recently.
 
 ## Contributing
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING.md](https://github.com/watercrawl/watercrawl-php/blob/main/CONTRIBUTING.md) for details.
 
 ## Security
 
@@ -78,4 +303,4 @@ If you discover any security related issues, please email security@watercrawl.de
 
 ## License
 
-The MIT License (MIT). Please see [License File](LICENSE) for more information.
+The MIT License (MIT). Please see [License File](https://github.com/watercrawl/watercrawl-php/blob/main/LICENSE) for more information.

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,14 @@
     "description": "PHP SDK for WaterCrawl REST APIs",
     "type": "library",
     "require": {
-        "php": "^7.4|^8.0",
-        "guzzlehttp/guzzle": "^7.0",
-        "ext-mbstring": "*"
+        "php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
+        "guzzlehttp/guzzle": "^7.5",
+        "ext-mbstring": "*",
+        "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
-        "squizlabs/php_codesniffer": "^3.0"
+        "phpunit/phpunit": "^9.6",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "license": "MIT",
     "autoload": {
@@ -30,5 +31,9 @@
         "cs": "phpcs",
         "cs-fix": "phpcbf"
     },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    },
     "minimum-stability": "stable"
-} 
+}

--- a/src/APIClient.php
+++ b/src/APIClient.php
@@ -17,6 +17,34 @@ class APIClient extends BaseAPIClient
 
     /**
      * @param ResponseInterface $response
+     * @return array|string|Generator|null
+     * @throws RuntimeException
+     */
+    protected function processResponse(ResponseInterface $response)
+    {
+        $contentType = $response->getHeaderLine('Content-Type');
+
+        if ($response->getStatusCode() === 204) {
+            return null;
+        }
+
+        if (str_contains($contentType, 'application/json')) {
+            return json_decode($response->getBody()->getContents(), true);
+        }
+
+        if (str_contains($contentType, 'application/octet-stream') || str_contains($contentType, 'application/zip')) {
+            return $response->getBody()->getContents();
+        }
+
+        if (str_contains($contentType, 'text/event-stream')) {
+            return $this->processEventstream($response);
+        }
+
+        throw new RuntimeException("Unknown response type: {$contentType}");
+    }
+
+    /**
+     * @param ResponseInterface $response
      * @return Generator
      */
     protected function processEventstream(ResponseInterface $response): Generator
@@ -50,34 +78,6 @@ class APIClient extends BaseAPIClient
                 yield $data;
             }
         }
-    }
-
-    /**
-     * @param ResponseInterface $response
-     * @return array|string|Generator|null
-     * @throws RuntimeException
-     */
-    protected function processResponse(ResponseInterface $response): array|string|Generator|null
-    {
-        $contentType = $response->getHeaderLine('Content-Type');
-
-        if ($response->getStatusCode() === 204) {
-            return null;
-        }
-
-        if (str_contains($contentType, 'application/json')) {
-            return json_decode($response->getBody()->getContents(), true);
-        }
-
-        if (str_contains($contentType, 'application/octet-stream') || str_contains($contentType, 'application/zip')) {
-            return $response->getBody()->getContents();
-        }
-
-        if (str_contains($contentType, 'text/event-stream')) {
-            return $this->processEventstream($response);
-        }
-
-        throw new RuntimeException("Unknown response type: {$contentType}");
     }
 
     /**
@@ -143,7 +143,7 @@ class APIClient extends BaseAPIClient
      * @return null|array
      * @throws GuzzleException
      */
-    public function stopCrawlRequest(string $itemId): null|array
+    public function stopCrawlRequest(string $itemId)
     {
         return $this->processResponse(
             $this->delete("/api/v1/core/crawl-requests/{$itemId}/")
@@ -370,16 +370,17 @@ class APIClient extends BaseAPIClient
      * @param int|null $resultLimit Maximum number of results to return
      * @param bool $sync If true, wait for results; if false, return immediately
      * @param bool $download If true, download results; if false, return URLs
-     * @return array|Generator Either search results (if sync=true) or search request object (if sync=false)
+     * @return array|Generator
      * @throws GuzzleException
+     * @throws RuntimeException
      */
     public function createSearchRequest(
         string $query,
         ?array $searchOptions = null,
-        ?int $resultLimit = 5,
+        ?int $resultLimit = null,
         bool $sync = true,
         bool $download = true
-    ): array|Generator {
+    ) {
         $response = $this->processResponse(
             $this->post(
                 '/api/v1/core/search/',
@@ -431,7 +432,7 @@ class APIClient extends BaseAPIClient
      * @return null|array
      * @throws GuzzleException
      */
-    public function stopSearchRequest(string $itemId): null|array
+    public function stopSearchRequest(string $itemId)
     {
         return $this->processResponse(
             $this->delete("/api/v1/core/search/{$itemId}/")

--- a/src/APIClient.php
+++ b/src/APIClient.php
@@ -17,10 +17,9 @@ class APIClient extends BaseAPIClient
 
     /**
      * @param ResponseInterface $response
-     * @param bool $download
      * @return Generator
      */
-    protected function processEventstream(ResponseInterface $response, bool $download = false): Generator
+    protected function processEventstream(ResponseInterface $response): Generator
     {
         $buffer = '';
         $stream = $response->getBody();
@@ -37,12 +36,7 @@ class APIClient extends BaseAPIClient
                 if (str_starts_with($line, 'data:')) {
                     $line = trim(substr($line, 5));
                     $data = json_decode($line, true);
-                    if ($data && isset($data['type']) && $data['type'] === 'result' && $download) {
-                        $data['data'] = $this->downloadResult($data['data']);
-                    }
-                    if ($data) {
-                        yield $data;
-                    }
+                    yield $data;
                 }
             }
         }
@@ -53,23 +47,17 @@ class APIClient extends BaseAPIClient
             if (str_starts_with($line, 'data:')) {
                 $line = trim(substr($line, 5));
                 $data = json_decode($line, true);
-                if ($data && isset($data['type']) && $data['type'] === 'result' && $download) {
-                    $data['data'] = $this->downloadResult($data['data']);
-                }
-                if ($data) {
-                    yield $data;
-                }
+                yield $data;
             }
         }
     }
 
     /**
      * @param ResponseInterface $response
-     * @param bool $download
      * @return array|string|Generator|null
      * @throws RuntimeException
      */
-    protected function processResponse(ResponseInterface $response, bool $download = false)
+    protected function processResponse(ResponseInterface $response): array|string|Generator|null
     {
         $contentType = $response->getHeaderLine('Content-Type');
 
@@ -81,12 +69,12 @@ class APIClient extends BaseAPIClient
             return json_decode($response->getBody()->getContents(), true);
         }
 
-        if (str_contains($contentType, 'application/octet-stream')) {
+        if (str_contains($contentType, 'application/octet-stream') || str_contains($contentType, 'application/zip')) {
             return $response->getBody()->getContents();
         }
 
         if (str_contains($contentType, 'text/event-stream')) {
-            return $this->processEventstream($response, $download);
+            return $this->processEventstream($response);
         }
 
         throw new RuntimeException("Unknown response type: {$contentType}");
@@ -152,10 +140,10 @@ class APIClient extends BaseAPIClient
 
     /**
      * @param string $itemId
-     * @return null
+     * @return null|array
      * @throws GuzzleException
      */
-    public function stopCrawlRequest(string $itemId)
+    public function stopCrawlRequest(string $itemId): null|array
     {
         return $this->processResponse(
             $this->delete("/api/v1/core/crawl-requests/{$itemId}/")
@@ -169,9 +157,16 @@ class APIClient extends BaseAPIClient
      */
     public function downloadCrawlRequest(string $itemId): array
     {
-        return $this->processResponse(
+        $response = $this->processResponse(
             $this->get("/api/v1/core/crawl-requests/{$itemId}/download/")
         );
+
+        // Handle string response (binary data) by wrapping it in an array
+        if (is_string($response)) {
+            return ['data' => $response, 'content_type' => 'application/zip'];
+        }
+
+        return $response;
     }
 
     /**
@@ -185,10 +180,9 @@ class APIClient extends BaseAPIClient
         return $this->processResponse(
             $this->get(
                 "/api/v1/core/crawl-requests/{$itemId}/status/",
-                null,
+                ['prefetched' => $download],
                 [RequestOptions::STREAM => true]
-            ),
-            $download
+            )
         );
     }
 
@@ -261,4 +255,186 @@ class APIClient extends BaseAPIClient
         $resultObject['result'] = json_decode($response->getBody()->getContents(), true);
         return $resultObject;
     }
-} 
+
+    /**
+     * Helper method to get a crawl request for sitemap operations
+     * 
+     * @param string|array $crawlRequest Either a crawl request UUID string or a crawl request object
+     * @return array Crawl request object
+     * @throws GuzzleException If the crawl request cannot be fetched
+     * @throws RuntimeException If the sitemap is not found in the crawl request
+     */
+    private function getCrawlRequestForSitemap($crawlRequest): array
+    {
+        if (is_string($crawlRequest)) {
+            $crawlRequest = $this->getCrawlRequest($crawlRequest);
+        }
+
+        if (!isset($crawlRequest['sitemap']) || empty($crawlRequest['sitemap'])) {
+            throw new RuntimeException('Sitemap not found in crawl request');
+        }
+
+        return $crawlRequest;
+    }
+
+    /**
+     * Download the sitemap for a given crawl request
+     * 
+     * @param string|array $crawlRequest Either a crawl request UUID string or a crawl request object
+     * @return array The sitemap data as an array
+     * @throws GuzzleException If there's an error fetching the sitemap
+     * @throws RuntimeException If the sitemap is not found in the crawl request
+     */
+    public function downloadSitemap($crawlRequest): array
+    {
+        $crawlRequest = $this->getCrawlRequestForSitemap($crawlRequest);
+        $response = $this->httpClient->request('GET', $crawlRequest['sitemap']);
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    /**
+     * Download the sitemap as a graph representation
+     * 
+     * @param string|array $crawlRequest Either a crawl request UUID string or a crawl request object
+     * @return array The graph data
+     * @throws GuzzleException If there's an error fetching the sitemap graph
+     * @throws RuntimeException If the sitemap is not found in the crawl request
+     */
+    public function downloadSitemapGraph($crawlRequest): array
+    {
+        $crawlRequest = $this->getCrawlRequestForSitemap($crawlRequest);
+        $url = str_replace('/json', '/graph', $crawlRequest['sitemap']);
+        $response = $this->httpClient->request('GET', $url);
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    /**
+     * Download the sitemap as markdown
+     * 
+     * @param string|array $crawlRequest Either a crawl request UUID string or a crawl request object
+     * @return string The sitemap as markdown text
+     * @throws GuzzleException If there's an error fetching the markdown
+     * @throws RuntimeException If the sitemap is not found in the crawl request
+     */
+    public function downloadSitemapMarkdown($crawlRequest): string
+    {
+        $crawlRequest = $this->getCrawlRequestForSitemap($crawlRequest);
+        $url = str_replace('/json', '/markdown', $crawlRequest['sitemap']);
+        $response = $this->httpClient->request('GET', $url);
+
+        return $response->getBody()->getContents();
+    }
+
+    /**
+     * Get a list of search requests
+     * 
+     * @param int|null $page Page number
+     * @param int|null $pageSize Number of results per page
+     * @return array List of search requests
+     * @throws GuzzleException
+     */
+    public function getSearchRequestsList(?int $page = null, ?int $pageSize = null): array
+    {
+        $queryParams = [
+            'page' => $page ?? 1,
+            'page_size' => $pageSize ?? 10
+        ];
+
+        return $this->processResponse(
+            $this->get('/api/v1/core/search/', $queryParams)
+        );
+    }
+
+    /**
+     * Get details of a specific search request
+     * 
+     * @param string $itemId UUID of the search request
+     * @param bool $download If true, download results; if false, return URLs
+     * @return array Search request details
+     * @throws GuzzleException
+     */
+    public function getSearchRequest(string $itemId, bool $download = true): array
+    {
+        return $this->processResponse(
+            $this->get("/api/v1/core/search/{$itemId}/", ['prefetched' => $download])
+        );
+    }
+
+    /**
+     * Create a new search request
+     * 
+     * @param string $query Search query
+     * @param array|null $searchOptions Search options (language, country, time_range, search_type, depth)
+     * @param int|null $resultLimit Maximum number of results to return
+     * @param bool $sync If true, wait for results; if false, return immediately
+     * @param bool $download If true, download results; if false, return URLs
+     * @return array|Generator Either search results (if sync=true) or search request object (if sync=false)
+     * @throws GuzzleException
+     */
+    public function createSearchRequest(
+        string $query,
+        ?array $searchOptions = null,
+        ?int $resultLimit = 5,
+        bool $sync = true,
+        bool $download = true
+    ): array|Generator {
+        $response = $this->processResponse(
+            $this->post(
+                '/api/v1/core/search/',
+                null,
+                [
+                    'query' => $query,
+                    'search_options' => (object)($searchOptions ?? new \stdClass()),
+                    'result_limit' => $resultLimit
+                ]
+            )
+        );
+
+        if (!$sync) {
+            return $response;
+        }
+
+        foreach ($this->monitorSearchRequest($response['uuid'], $download) as $result) {
+            if ($result['type'] === 'state' && $result['status'] === 'finished') {
+                return $result['data'];
+            }
+        }
+
+        throw new RuntimeException('Search request failed or timed out');
+    }
+
+    /**
+     * Monitor a search request in real-time
+     * 
+     * @param string $itemId UUID of the search request to monitor
+     * @param bool $download If true, download results; if false, return URLs
+     * @return Generator Generator yielding search events
+     * @throws GuzzleException
+     */
+    public function monitorSearchRequest(string $itemId, bool $download = true): Generator
+    {
+        return $this->processResponse(
+            $this->get(
+                "/api/v1/core/search/{$itemId}/status/",
+                ['prefetched' => $download],
+                [RequestOptions::STREAM => true]
+            )
+        );
+    }
+
+    /**
+     * Stop a running search request
+     * 
+     * @param string $itemId UUID of the search request to stop
+     * @return null|array
+     * @throws GuzzleException
+     */
+    public function stopSearchRequest(string $itemId): null|array
+    {
+        return $this->processResponse(
+            $this->delete("/api/v1/core/search/{$itemId}/")
+        );
+    }
+}

--- a/src/BaseAPIClient.php
+++ b/src/BaseAPIClient.php
@@ -9,18 +9,32 @@ use Psr\Http\Message\ResponseInterface;
 
 class BaseAPIClient
 {
-    protected string $apiKey;
-    protected string $baseUrl;
-    protected ClientInterface $httpClient;
+    /**
+     * @var string
+     */
+    protected $apiKey;
+    
+    /**
+     * @var string
+     */
+    protected $baseUrl;
+    
+    /**
+     * @var ClientInterface
+     */
+    protected $httpClient;
 
-    public function __construct(string $apiKey, string $baseUrl)
+    public function __construct($apiKey, $baseUrl)
     {
         $this->apiKey = $apiKey;
         $this->baseUrl = $baseUrl;
         $this->httpClient = $this->initSession();
     }
 
-    protected function initSession(): ClientInterface
+    /**
+     * @return ClientInterface
+     */
+    protected function initSession()
     {
         return new GuzzleClient([
             'base_uri' => $this->baseUrl,
@@ -34,13 +48,26 @@ class BaseAPIClient
         ]);
     }
 
-    protected function get(string $endpoint, ?array $queryParams = null, array $options = []): ResponseInterface
+    /**
+     * @param string $endpoint
+     * @param array|null $queryParams
+     * @param array $options
+     * @return ResponseInterface
+     */
+    protected function get($endpoint, $queryParams = null, $options = [])
     {
         $options[RequestOptions::QUERY] = $queryParams ?? [];
         return $this->httpClient->request('GET', $endpoint, $options);
     }
 
-    protected function post(string $endpoint, ?array $queryParams = null, ?array $data = null, array $options = []): ResponseInterface
+    /**
+     * @param string $endpoint
+     * @param array|null $queryParams
+     * @param array|null $data
+     * @param array $options
+     * @return ResponseInterface
+     */
+    protected function post($endpoint, $queryParams = null, $data = null, $options = [])
     {
         $options[RequestOptions::QUERY] = $queryParams ?? [];
         if ($data !== null) {
@@ -49,7 +76,14 @@ class BaseAPIClient
         return $this->httpClient->request('POST', $endpoint, $options);
     }
 
-    protected function put(string $endpoint, ?array $queryParams = null, ?array $data = null, array $options = []): ResponseInterface
+    /**
+     * @param string $endpoint
+     * @param array|null $queryParams
+     * @param array|null $data
+     * @param array $options
+     * @return ResponseInterface
+     */
+    protected function put($endpoint, $queryParams = null, $data = null, $options = [])
     {
         $options[RequestOptions::QUERY] = $queryParams ?? [];
         if ($data !== null) {
@@ -58,13 +92,26 @@ class BaseAPIClient
         return $this->httpClient->request('PUT', $endpoint, $options);
     }
 
-    protected function delete(string $endpoint, ?array $queryParams = null, array $options = []): ResponseInterface
+    /**
+     * @param string $endpoint
+     * @param array|null $queryParams
+     * @param array $options
+     * @return ResponseInterface
+     */
+    protected function delete($endpoint, $queryParams = null, $options = [])
     {
         $options[RequestOptions::QUERY] = $queryParams ?? [];
         return $this->httpClient->request('DELETE', $endpoint, $options);
     }
 
-    protected function patch(string $endpoint, ?array $queryParams = null, ?array $data = null, array $options = []): ResponseInterface
+    /**
+     * @param string $endpoint
+     * @param array|null $queryParams
+     * @param array|null $data
+     * @param array $options
+     * @return ResponseInterface
+     */
+    protected function patch($endpoint, $queryParams = null, $data = null, $options = [])
     {
         $options[RequestOptions::QUERY] = $queryParams ?? [];
         if ($data !== null) {

--- a/src/BaseAPIClient.php
+++ b/src/BaseAPIClient.php
@@ -72,4 +72,4 @@ class BaseAPIClient
         }
         return $this->httpClient->request('PATCH', $endpoint, $options);
     }
-} 
+}

--- a/tests/WaterCrawlAPITest.php
+++ b/tests/WaterCrawlAPITest.php
@@ -123,7 +123,6 @@ class WaterCrawlAPITest extends TestCase
         $downloadResponse = $this->api->downloadResult($result);
         $this->assertIsArray($downloadResponse);
         $this->assertIsArray($downloadResponse['result']);
-
     }
 
     public function testScrapeUrl(): void
@@ -140,4 +139,230 @@ class WaterCrawlAPITest extends TestCase
             throw $e;
         }
     }
-} 
+
+    // New tests for search functionality
+    public function testGetSearchRequestsList(): void
+    {
+        $response = $this->api->getSearchRequestsList();
+        $this->assertIsArray($response['results']);
+    }
+
+    public function testCreateSearchRequest(): void
+    {
+        try {
+            // Create an async search request to not wait for results
+            $response = $this->api->createSearchRequest('php library', [], 2, false);
+            $this->assertIsArray($response);
+            $this->assertArrayHasKey('uuid', $response);
+
+            // Clean up after test
+            try {
+                $this->api->stopSearchRequest($response['uuid']);
+            } catch (\Exception $e) {
+                // Ignore errors on cleanup
+            }
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 403) {
+                $this->markTestSkipped('API plan does not support concurrent searches');
+            }
+            throw $e;
+        }
+    }
+
+    public function testGetSearchRequest(): void
+    {
+        try {
+            // Create a search request first
+            $request = $this->api->createSearchRequest('php tutorial', [], 2, false);
+            
+            // Get the details
+            $response = $this->api->getSearchRequest($request['uuid']);
+            $this->assertIsArray($response);
+            $this->assertArrayHasKey('uuid', $response);
+            $this->assertArrayHasKey('query', $response);
+            $this->assertEquals('php tutorial', $response['query']);
+
+            // Clean up after test
+            try {
+                $this->api->stopSearchRequest($request['uuid']);
+            } catch (\Exception $e) {
+                // Ignore errors on cleanup
+            }
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 403) {
+                $this->markTestSkipped('API plan does not support concurrent searches');
+            }
+            throw $e;
+        }
+    }
+
+    public function testGetSearchRequestWithDownload(): void
+    {
+        try {
+            // Create a search request first
+            $request = $this->api->createSearchRequest('php programming', [], 2, false);
+
+            foreach ($this->api->monitorSearchRequest($request['uuid'], false) as $item) {
+                if ($item['type'] === 'state' && $item['data']['status'] === 'finished') {
+                    break;
+                }
+            }
+            
+            // Get the details with download=true
+            $response = $this->api->getSearchRequest($request['uuid'], true);
+            $this->assertIsArray($response);
+            $this->assertArrayHasKey('uuid', $response);
+            
+            $this->assertArrayHasKey('result', $response);
+            $this->assertIsArray($response['result']);
+            
+
+            // Test with download=false for comparison
+            $responseNoDownload = $this->api->getSearchRequest($request['uuid'], false);
+            $this->assertIsString($responseNoDownload['result']);
+            
+            // Clean up after test
+            try {
+                $this->api->stopSearchRequest($request['uuid']);
+            } catch (\Exception $e) {
+                // Ignore errors on cleanup
+            }
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 403) {
+                $this->markTestSkipped('API plan does not support concurrent searches');
+            }
+            throw $e;
+        }
+    }
+
+    public function testMonitorSearchRequest(): void
+    {
+        try {
+            // Create a search request first
+            $request = $this->api->createSearchRequest('php sdk', [], 2, false);
+            
+            // Test monitoring
+            $generator = $this->api->monitorSearchRequest($request['uuid'], false);
+            
+            // Just test first few events to keep test duration reasonable
+            $count = 0;
+            foreach ($generator as $event) {
+                $this->assertIsArray($event);
+                $this->assertArrayHasKey('type', $event);
+                $count++;
+                if ($count >= 2) break;
+            }
+
+            // Clean up after test
+            try {
+                $this->api->stopSearchRequest($request['uuid']);
+            } catch (\Exception $e) {
+                // Ignore errors on cleanup
+            }
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 403) {
+                $this->markTestSkipped('API plan does not support concurrent searches');
+            }
+            throw $e;
+        }
+    }
+
+    public function testStopSearchRequest(): void
+    {
+        try {
+            // Create a search request first
+            $request = $this->api->createSearchRequest('php framework', [], 2, false);
+            
+            // Wait a bit to ensure the request is registered
+            sleep(1);
+            
+            // Stop it
+            $response = $this->api->stopSearchRequest($request['uuid']);
+            $this->assertNull($response);
+            
+            // Verify it was stopped
+            $status = $this->api->getSearchRequest($request['uuid']);
+            $this->assertContains($status['status'], ['canceled', 'cancelled', 'failed', 'finished']);
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 403) {
+                $this->markTestSkipped('API plan does not support concurrent searches');
+            }
+            throw $e;
+        }
+    }
+
+    // Tests for sitemap functionality
+    public function testDownloadSitemap(): void
+    {
+        // Find a crawl with a sitemap first
+        $crawlWithSitemap = null;
+        $items = $this->api->getCrawlRequestsList();
+        
+        foreach ($items['results'] as $item) {
+            try {
+                $crawl = $this->api->getCrawlRequest($item['uuid']);
+                if (isset($crawl['sitemap']) && !empty($crawl['sitemap'])) {
+                    $crawlWithSitemap = $crawl;
+                    break;
+                }
+            } catch (\Exception $e) {
+                // Skip this item if it can't be retrieved
+                continue;
+            }
+        }
+        
+        if (!$crawlWithSitemap) {
+            $this->markTestSkipped('No crawl requests with sitemap found for testing');
+            return;
+        }
+        
+        // Test downloading sitemap using crawl object
+        $sitemap = $this->api->downloadSitemap($crawlWithSitemap);
+        $this->assertTrue(is_array($sitemap));
+        
+        // Test downloading sitemap using UUID string
+        $sitemapById = $this->api->downloadSitemap($crawlWithSitemap['uuid']);
+        $this->assertTrue(is_array($sitemapById));
+    }
+    
+    public function testSitemapGraphAndMarkdown(): void
+    {
+        // Find a crawl with a sitemap first
+        $crawlWithSitemap = null;
+        $items = $this->api->getCrawlRequestsList();
+        
+        foreach ($items['results'] as $item) {
+            try {
+                $crawl = $this->api->getCrawlRequest($item['uuid']);
+                if (isset($crawl['sitemap']) && !empty($crawl['sitemap'])) {
+                    $crawlWithSitemap = $crawl;
+                    break;
+                }
+            } catch (\Exception $e) {
+                // Skip this item if it can't be retrieved
+                continue;
+            }
+        }
+        
+        if (!$crawlWithSitemap) {
+            $this->markTestSkipped('No crawl requests with sitemap found for testing');
+            return;
+        }
+        
+        // Test downloading sitemap graph
+        try {
+            $graph = $this->api->downloadSitemapGraph($crawlWithSitemap['uuid']);
+            $this->assertTrue(is_array($graph));
+        } catch (\Exception $e) {
+            $this->markTestSkipped('Sitemap graph endpoint might not be supported yet: ' . $e->getMessage());
+        }
+        
+        // Test downloading sitemap markdown
+        try {
+            $markdown = $this->api->downloadSitemapMarkdown($crawlWithSitemap['uuid']);
+            $this->assertTrue(is_string($markdown));
+        } catch (\Exception $e) {
+            $this->markTestSkipped('Sitemap markdown endpoint might not be supported yet: ' . $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
- Add MIT license file with copyright for WaterCrawl-PHP
- Rename from 'SDK' to 'Client' throughout entire codebase for consistency
-  Expand README with comprehensive API examples including crawling operations, search functionality, and sitemap features
-  Add new test cases for sitemap functionality including downloadSitemap, downloadSitemapGraph, and downloadSitemapMarkdown methods
-  Update APIClient with new methods supporting v0.7.1 API endpoints
- Update composer.json with appropriate dependencies and metadata
- Implement error handling for API plan limitations in tests

Resolve https://github.com/watercrawl/WaterCrawl/issues/38